### PR TITLE
Monitoring 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,7 @@ A lightweight, high-performance file server written in Rust featuring **bidirect
 - **Rate Limiting** – DoS protection with configurable requests per minute and concurrent connections per IP
 - **Server Statistics** – Real-time monitoring of requests, bytes served, uptime, and performance metrics
 - **Health Check Endpoints** – Built-in `/_health` and `/_status` endpoints for monitoring
+- **Unified Monitoring Dashboard** – NEW `/monitor` endpoint with live HTML dashboard and JSON API (`/monitor?json=1`) exposing request, download and upload metrics
 - **Path-Traversal Protection** – Canonicalises every request path and rejects any attempt that escapes the served directory
 - **Optional Basic Authentication** – Username and password can be supplied via CLI flags
 
@@ -116,6 +117,53 @@ IronDrop v2.5 introduces a **production-ready file upload system** with enterpri
 - **🛡️ Robust Validation**: Multi-layer security including extension filtering, size limits, and malformed data rejection
 - **🧪 Battle-Tested**: 101+ tests covering edge cases, security scenarios, and performance stress testing
 
+### 📊 **Integrated Monitoring Dashboard** (Added in v2.5)
+The new `/monitor` endpoint provides both an HTML dashboard and a JSON API for tooling integration. It auto-updates in the browser and can be scraped by observability agents.
+
+Example JSON (`GET /monitor?json=1`):
+
+```json
+{
+   "requests": {
+      "total": 42,
+      "successful": 40,
+      "errors": 2,
+      "bytes_served": 1048576,
+      "uptime_secs": 360
+   },
+   "downloads": {
+      "bytes_served": 1048576
+   },
+   "uploads": {
+      "total_uploads": 5,
+      "successful_uploads": 5,
+      "failed_uploads": 0,
+      "files_uploaded": 7,
+      "upload_bytes": 5242880,
+      "average_upload_size": 748982,
+      "largest_upload": 2097152,
+      "concurrent_uploads": 0,
+      "average_processing_time": 152.4,
+      "success_rate": 100.0
+   }
+}
+```
+
+HTML Dashboard (`GET /monitor`):
+- Lightweight embedded template (no external assets) served with caching disabled for freshness
+- Auto-refresh JavaScript polling (`?json=1`) to update counters
+- Shows cumulative bytes served (downloads) and upload metrics side-by-side
+
+Use cases:
+- Local debugging of throughput
+- Basic operational visibility without external APM
+- Simple integration point for external monitoring (curl + jq / cron)
+
+Planned extensions (open to contribution):
+- Active connection count
+- Per-endpoint breakdown & rolling window rates
+- Exporter mode (Prometheus/OpenMetrics formatting)
+
 ### 🏗️ **Architecture Improvements**
 - **Enhanced Multipart Parser**: Robust RFC-compliant parsing with streaming support
 - **Improved Error Handling**: Graceful handling of malformed requests and resource exhaustion
@@ -152,6 +200,7 @@ IronDrop v2.5 introduces a **production-ready file upload system** with enterpri
 | **Secure Corporate Share** | `irondrop -d ./private --username alice --password s3cret` | Authentication, audit logging, professional design |
 | **Development Server** | `irondrop -d . -v --detailed-logging` | Debug logging, template development, hot reload |
 | **Production Monitoring** | `irondrop -d /data -l 0.0.0.0` + health checks at `/_health` | Statistics, uptime monitoring, rate limiting |
+| **Monitoring Dashboard** | `irondrop -d .` then visit `/monitor` | Live HTML + JSON metrics |
 | **Secure Upload Server** | `irondrop -d ./shared --enable-upload --max-upload-size 5120 -a "*.txt,*.pdf,*.jpg"` | Controlled file uploads up to 5GB, extension filtering |
 | **Corporate File Share** | `irondrop -d /data --enable-upload --upload-dir /data/uploads --username admin` | Authenticated uploads, custom upload directory |
 

--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -360,6 +360,58 @@ Detailed server status and statistics.
 }
 ```
 
+#### `GET /monitor`
+HTML monitoring dashboard (human-friendly) that auto-refreshes via JavaScript to show live server statistics. Provides request counts, bytes served (downloads), and upload metrics (counts, bytes, success rate, concurrency, average processing time).
+
+**Response (HTML):**
+```http
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html>
+  <!-- Embedded dashboard template -->
+</html>
+```
+
+#### `GET /monitor?json=1`
+Machine-readable JSON stats for integration with external monitoring / scripting.
+
+**Response (JSON):**
+```json
+{
+  "requests": {
+    "total": 42,
+    "successful": 40,
+    "errors": 2,
+    "bytes_served": 1048576,
+    "uptime_secs": 360
+  },
+  "downloads": {
+    "bytes_served": 1048576
+  },
+  "uploads": {
+    "total_uploads": 5,
+    "successful_uploads": 5,
+    "failed_uploads": 0,
+    "files_uploaded": 7,
+    "upload_bytes": 5242880,
+    "average_upload_size": 748982,
+    "largest_upload": 2097152,
+    "concurrent_uploads": 0,
+    "average_processing_time": 152.4,
+    "success_rate": 100.0
+  }
+}
+```
+
+**Notes:**
+- `bytes_served` counts only response body bytes (excludes headers).
+- `average_processing_time` is the rolling average (last 100 uploads).
+- All counters are cumulative since server start.
+
+**Planned Extensions (future versions):** active connections, per-endpoint metrics, Prometheus format.
+
 ### 6. API Information
 
 #### `GET /_api`

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -57,6 +57,7 @@ IronDrop is a lightweight, high-performance file server written in Rust featurin
 ### 5. **Support Systems**
 - **`error.rs`**: Custom error types and error handling
 - **`utils.rs`**: Utility functions and helper methods
+ - **Monitoring (integrated)**: `/monitor` endpoint (HTML + JSON) implemented inside `http.rs` using `ServerStats` from `server.rs`.
 
 ## Request Processing Flow
 
@@ -172,6 +173,7 @@ tests/
    - Comprehensive request logging with unique IDs
    - Performance metrics collection and statistics
    - Health check endpoints (`/_health`, `/_status`)
+   - Unified monitoring dashboard (`/monitor`, `/monitor?json=1`)
    - Error tracking and security event logging
 
 ### Security Features by Component

--- a/doc/MONITORING.md
+++ b/doc/MONITORING.md
@@ -1,0 +1,128 @@
+# IronDrop Monitoring Guide (v2.5)
+
+This guide documents the built-in monitoring capabilities introduced with the `/monitor` endpoint and supporting health APIs.
+
+## Overview
+
+IronDrop exposes lightweight operational telemetry without external dependencies:
+
+| Endpoint | Format | Purpose |
+|----------|--------|---------|
+| `/monitor` | HTML | Human dashboard for live stats |
+| `/monitor?json=1` | JSON | Machine-readable metrics for scripting / scraping |
+| `/_health` | JSON | Minimal liveness probe (OK / version / uptime) |
+| `/_status` | JSON | Extended status (configuration + cumulative counters) |
+
+## Data Model
+
+`/monitor?json=1` returns three top-level sections:
+
+```json
+{
+  "requests": {
+    "total": 42,
+    "successful": 40,
+    "errors": 2,
+    "bytes_served": 1048576,
+    "uptime_secs": 360
+  },
+  "downloads": {
+    "bytes_served": 1048576
+  },
+  "uploads": {
+    "total_uploads": 5,
+    "successful_uploads": 5,
+    "failed_uploads": 0,
+    "files_uploaded": 7,
+    "upload_bytes": 5242880,
+    "average_upload_size": 748982,
+    "largest_upload": 2097152,
+    "concurrent_uploads": 0,
+    "average_processing_time": 152.4,
+    "success_rate": 100.0
+  }
+}
+```
+
+### Field Semantics
+- `requests.total` – All handled requests (success + error) since start.
+- `requests.successful` / `errors` – Outcome classification.
+- `requests.bytes_served` / `downloads.bytes_served` – Cumulative body bytes sent (excludes HTTP headers) across all responses.
+- `requests.uptime_secs` – Elapsed seconds since the first server start instant.
+- `uploads.*` – Aggregated upload subsystem metrics (only updated when uploads enabled).
+- `average_processing_time` – Rolling average (last 100 uploads) in milliseconds.
+- `success_rate` – Percentage of successful uploads over total uploads (0 if none yet).
+- `concurrent_uploads` – Point-in-time counter incremented on start and decremented on completion.
+
+## HTML Dashboard
+The `/monitor` HTML view is an embedded template with:
+- No external network calls (all assets embedded) 
+- Auto-refresh polling every 30 seconds (JavaScript fetch to `?json=1`)
+- Separate sections for Requests, Downloads, Uploads
+
+## Usage Examples
+
+### Quick CLI Scrape
+```bash
+curl -s http://localhost:8080/monitor?json=1 | jq '.requests.bytes_served'
+```
+
+### Basic Health Probe (Kubernetes / Docker)
+```bash
+curl -f http://localhost:8080/_health > /dev/null || echo "Unhealthy"
+```
+
+### Shell Alert When Upload Failures Detected
+```bash
+if [ "$(curl -s http://localhost:8080/monitor?json=1 | jq '.uploads.failed_uploads')" -gt 0 ]; then
+  echo "Upload failures detected" >&2
+fi
+```
+
+### Log Requests per Minute (Approximate)
+```bash
+prev=0
+while sleep 60; do
+  cur=$(curl -s http://localhost:8080/monitor?json=1 | jq '.requests.total')
+  echo "RPM=$((cur-prev))"
+  prev=$cur
+done
+```
+
+## Integration Guidelines
+- Poll interval recommendation: 15–60s (dashboard uses 30s).
+- For higher resolution, build a sidecar scraper and aggregate externally.
+- Avoid sub-second polling—counters are cumulative and inexpensive but not real-time high-frequency telemetry.
+
+## Design Notes
+- Byte counting performed at response write boundary (body only) to avoid skew from variable header length.
+- Upload averages retained in a fixed-size ring (truncate beyond 100 samples) to bound memory.
+- Stats guarded by `Arc<Mutex<T>>`; contention is minimal under typical loads. Future optimization: swap to atomics + snapshot struct.
+
+## Extensibility Roadmap (Open for Contribution)
+| Feature | Description | Status |
+|---------|-------------|--------|
+| Active Connections | Live in-flight connection count | Planned |
+| Per-Endpoint Stats | Breakdown by route (/, /upload, /monitor, static) | Planned |
+| Prometheus Export | `/metrics` in OpenMetrics format | Planned |
+| Rolling Rates | Requests/sec and upload throughput windows | Planned |
+| Error Categorization | Distribution by HTTP status class | Planned |
+
+## Security Considerations
+- Endpoint intentionally unauthenticated to support lightweight self-host setups; wrap behind reverse proxy if sensitive.
+- For private deployments: require Basic Auth (same as other routes) or network ACLs.
+- No user-identifying data exposed—only aggregate counters.
+
+## Troubleshooting
+| Symptom | Possible Cause | Action |
+|---------|----------------|--------|
+| `bytes_served` stays 0 | Only HEAD/empty responses so far or early fetch before first response recorded | Perform a file download then re-check |
+| Upload counters not changing | Uploads disabled (`--enable-upload` missing) | Start server with `--enable-upload` |
+| High error count | Client probing invalid paths | Inspect logs (`RUST_LOG=info` or `-v`) |
+| Negative/Unexpected averages | Mutex poisoning from panic (rare) | Check logs for prior panic, restart server |
+
+## Versioning
+Monitoring schema may evolve with additive fields. Consumers should ignore unknown keys. Breaking changes (renames/removals) will bump minor version >= 2.x.
+
+---
+*Monitoring Guide for IronDrop v2.5*

--- a/doc/README.md
+++ b/doc/README.md
@@ -106,6 +106,16 @@ This documentation suite provides complete coverage of IronDrop's architecture, 
 - Extensive test coverage for security scenarios
 
 ### 🔄 [Multipart Parser Documentation](./MULTIPART_README.md)
+### 📊 [Monitoring Guide](./MONITORING.md)
+**Audience**: Operators, Observability Engineers, SREs  
+**Purpose**: Details on `/monitor`, health endpoints, data model, integration patterns
+
+**Contents:**
+- `/monitor` HTML dashboard behavior and refresh model
+- `/monitor?json=1` schema and field semantics
+- Health vs status endpoint differences
+- Example automation + jq scraping patterns
+- Extensibility roadmap (Prometheus, per-endpoint stats)
 **Audience**: Backend Developers, Protocol Implementers  
 **Purpose**: RFC 7578 compliant multipart/form-data parser details
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -679,9 +679,6 @@ fn handle_client_with_stats(
     cli_config: Option<&crate::cli::Cli>,
 ) -> Result<(), AppError> {
     let start = Instant::now();
-    let bytes_sent = 0u64;
-
-    // Use existing handle_client but with error tracking
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         handle_client(
             stream,
@@ -698,8 +695,10 @@ fn handle_client_with_stats(
     let success = result.is_ok();
     let processing_time = start.elapsed();
 
-    // Record statistics
-    stats.record_request(success, bytes_sent);
+    // On panic, record failure (normal success/failure & bytes recorded in handle_client)
+    if !success {
+        stats.record_request(false, 0);
+    }
 
     if processing_time > Duration::from_millis(1000) {
         warn!(

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -14,6 +14,7 @@ const UPLOAD_PAGE_HTML: &str = include_str!("../templates/upload/page.html");
 const UPLOAD_STYLES_CSS: &str = include_str!("../templates/upload/styles.css");
 const UPLOAD_SCRIPT_JS: &str = include_str!("../templates/upload/script.js");
 const UPLOAD_FORM_HTML: &str = include_str!("../templates/upload/form.html");
+const MONITOR_PAGE_HTML: &str = include_str!("../templates/monitor/page.html");
 
 // Embed favicon files at compile time
 const FAVICON_ICO: &[u8] = include_bytes!("../favicon.ico");
@@ -44,6 +45,7 @@ impl TemplateEngine {
         templates.insert("error_page".to_string(), ERROR_PAGE_HTML.to_string());
         templates.insert("upload_page".to_string(), UPLOAD_PAGE_HTML.to_string());
         templates.insert("upload_form".to_string(), UPLOAD_FORM_HTML.to_string());
+        templates.insert("monitor_page".to_string(), MONITOR_PAGE_HTML.to_string());
 
         Self { templates }
     }
@@ -183,6 +185,11 @@ impl TemplateEngine {
         variables.insert("PATH".to_string(), path.to_string());
 
         self.render("upload_page", &variables)
+    }
+
+    /// Render monitor page (variables currently unused, placeholder for future extension)
+    pub fn render_monitor_page(&self) -> Result<String, AppError> {
+        self.render("monitor_page", &HashMap::new())
     }
 
     /// Get upload form component HTML

--- a/templates/monitor/page.html
+++ b/templates/monitor/page.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Server Monitor</title>
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body { font-family: system-ui,-apple-system,Arial,sans-serif; margin: 2rem; background:#0f1115; color:#e6e6e6; }
+    h1 { margin-top:0; font-size:1.9rem; }
+    .grid { display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); margin-top:1rem; }
+    .card { background:#1a1d23; border:1px solid #2a2f37; border-radius:10px; padding:1rem 1.1rem; box-shadow:0 2px 4px rgba(0,0,0,0.4); }
+    .card h2 { margin:0 0 .6rem; font-size:1.05rem; letter-spacing:.5px; font-weight:600; color:#9cc8ff; }
+    table { width:100%; border-collapse:collapse; font-size:.85rem; }
+    th, td { padding:.35rem .5rem; text-align:left; border-bottom:1px solid #2a2f37; vertical-align:top; }
+    th { font-weight:600; color:#b8dafc; }
+    tr:last-child td { border-bottom:none; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.8rem; }
+    footer { margin-top:2rem; font-size:.7rem; opacity:.5; }
+    .ok { color:#4ade80; }
+    .warn { color:#fbbf24; }
+    .err { color:#f87171; }
+  </style>
+</head>
+<body>
+  <h1>Server Monitor</h1>
+  <div id="status" class="mono"></div>
+  <div class="grid">
+    <div class="card">
+      <h2>Requests</h2>
+      <table>
+        <tr><th>Total</th><td id="req_total">-</td></tr>
+        <tr><th>Successful</th><td id="req_success">-</td></tr>
+        <tr><th>Errors</th><td id="req_errors">-</td></tr>
+        <tr><th>Success Rate</th><td id="req_success_rate">-</td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <h2>Downloads</h2>
+      <table>
+        <tr><th>Bytes Served</th><td id="bytes_served">-</td></tr>
+        <tr><th>Served (MB)</th><td id="mb_served">-</td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <h2>Uploads</h2>
+      <table>
+        <tr><th>Total Uploads</th><td id="up_total">-</td></tr>
+        <tr><th>Successful</th><td id="up_success">-</td></tr>
+        <tr><th>Failed</th><td id="up_failed">-</td></tr>
+        <tr><th>Files Uploaded</th><td id="files_uploaded">-</td></tr>
+        <tr><th>Bytes Uploaded</th><td id="up_bytes">-</td></tr>
+        <tr><th>Uploaded (MB)</th><td id="up_mb">-</td></tr>
+        <tr><th>Average File Size</th><td id="avg_file_size">-</td></tr>
+        <tr><th>Largest Upload</th><td id="largest_upload">-</td></tr>
+        <tr><th>Concurrent Uploads</th><td id="concurrent_uploads">-</td></tr>
+        <tr><th>Avg Processing (ms)</th><td id="avg_processing">-</td></tr>
+        <tr><th>Upload Success %</th><td id="upload_success_rate">-</td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <h2>Uptime</h2>
+      <table>
+        <tr><th>Seconds</th><td id="uptime_secs">-</td></tr>
+        <tr><th>Pretty</th><td id="uptime_pretty">-</td></tr>
+        <tr><th>Last Updated</th><td id="last_updated">-</td></tr>
+      </table>
+    </div>
+  </div>
+  <footer>Auto-refreshes every 30s. &copy; IronDrop Monitor</footer>
+  <script>
+    function humanBytes(b){ if(b<1024) return b+" B"; const u=['KB','MB','GB','TB']; let i=-1; do{ b/=1024; i++; }while(b>=1024 && i<u.length-1); return b.toFixed(2)+' '+u[i]; }
+    function prettyUptime(s){ const d=Math.floor(s/86400); s%=86400; const h=Math.floor(s/3600); s%=3600; const m=Math.floor(s/60); const sec=s%60; let out=[]; if(d) out.push(d+'d'); if(h) out.push(h+'h'); if(m) out.push(m+'m'); out.push(sec+'s'); return out.join(' '); }
+    async function load(){
+      try{
+        const res=await fetch('/monitor?json=1');
+        if(!res.ok) throw new Error('HTTP '+res.status);
+        const data=await res.json();
+        const r=data.requests, u=data.uploads, d=data.downloads;
+        document.getElementById('req_total').textContent=r.total;
+        document.getElementById('req_success').textContent=r.successful;
+        document.getElementById('req_errors').textContent=r.errors;
+        const successRate = r.total? ((r.successful/r.total)*100).toFixed(2)+'%':'0%';
+        document.getElementById('req_success_rate').textContent=successRate;
+        document.getElementById('bytes_served').textContent=d.bytes_served;
+        document.getElementById('mb_served').textContent=(d.bytes_served/1024/1024).toFixed(2);
+        document.getElementById('up_total').textContent=u.total_uploads;
+        document.getElementById('up_success').textContent=u.successful_uploads;
+        document.getElementById('up_failed').textContent=u.failed_uploads;
+        document.getElementById('files_uploaded').textContent=u.files_uploaded;
+        document.getElementById('up_bytes').textContent=u.upload_bytes;
+        document.getElementById('up_mb').textContent=(u.upload_bytes/1024/1024).toFixed(2);
+        document.getElementById('avg_file_size').textContent=humanBytes(u.average_upload_size);
+        document.getElementById('largest_upload').textContent=humanBytes(u.largest_upload);
+        document.getElementById('concurrent_uploads').textContent=u.concurrent_uploads;
+        document.getElementById('avg_processing').textContent=u.average_processing_ms?.toFixed?u.average_processing_ms.toFixed(1):u.average_processing_ms;
+        document.getElementById('upload_success_rate').textContent=u.success_rate.toFixed?u.success_rate.toFixed(2)+'%':u.success_rate+'%';
+        document.getElementById('uptime_secs').textContent=data.uptime_secs;
+        document.getElementById('uptime_pretty').textContent=prettyUptime(data.uptime_secs);
+        document.getElementById('last_updated').textContent=new Date().toLocaleTimeString();
+        document.getElementById('status').textContent='OK';
+        document.getElementById('status').className='mono ok';
+      }catch(e){
+        document.getElementById('status').textContent='Error: '+e.message;
+        document.getElementById('status').className='mono err';
+      }
+    }
+    load();
+    setInterval(load, 30000);
+  </script>
+</body>
+</html>

--- a/tests/monitor_test.rs
+++ b/tests/monitor_test.rs
@@ -1,0 +1,167 @@
+//! Tests for /monitor endpoint and bytes_served accounting.
+
+use irondrop::cli::Cli;
+use irondrop::server::run_server;
+use reqwest::blocking::Client;
+use reqwest::StatusCode;
+use std::fs::File;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use tempfile::{tempdir, TempDir};
+
+struct TestServer {
+    addr: SocketAddr,
+    shutdown_tx: mpsc::Sender<()>,
+    handle: Option<JoinHandle<()>>,
+    _temp_dir: TempDir,
+}
+
+fn setup_test_server() -> TestServer {
+    let dir = tempdir().unwrap();
+    // Create a test file with known content length
+    let file_path = dir.path().join("monitor_test.txt");
+    let mut f = File::create(&file_path).unwrap();
+    // Exact content (keep simple ASCII)
+    write!(f, "This is a monitor test file.").unwrap(); // 29 bytes
+
+    let cli = Cli {
+        directory: dir.path().to_path_buf(),
+        listen: "127.0.0.1".to_string(),
+        port: 0,
+        allowed_extensions: "*.txt".to_string(),
+        threads: 4,
+        chunk_size: 1024,
+        verbose: false,
+        detailed_logging: false,
+        username: None,
+        password: None,
+        enable_upload: false,
+        max_upload_size: 10240,
+        upload_dir: None,
+    };
+
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    let (addr_tx, addr_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        if let Err(e) = run_server(cli, Some(shutdown_rx), Some(addr_tx)) {
+            eprintln!("Server thread failed: {e}");
+        }
+    });
+
+    let addr = addr_rx.recv().unwrap();
+
+    TestServer {
+        addr,
+        shutdown_tx,
+        handle: Some(handle),
+        _temp_dir: dir,
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = self.shutdown_tx.send(());
+            let _ = handle.join();
+        }
+    }
+}
+
+fn extract_bytes_served(json: &str) -> u64 {
+    // Look for "bytes_served":<number>
+    if let Some(idx) = json.find("\"bytes_served\":") {
+        let slice = &json[idx + 15..];
+        let mut digits = String::new();
+        for ch in slice.chars() {
+            if ch.is_ascii_digit() {
+                digits.push(ch);
+            } else {
+                break;
+            }
+        }
+        if let Ok(v) = digits.parse::<u64>() {
+            return v;
+        }
+    }
+    panic!("bytes_served not found in json: {json}");
+}
+
+#[test]
+fn test_monitor_json_and_bytes_served_accounting() {
+    let server = setup_test_server();
+    let client = Client::new();
+
+    // First monitor fetch (baseline)
+    let res1 = client
+        .get(format!("http://{}/monitor?json=1", server.addr))
+        .send()
+        .unwrap();
+    assert_eq!(res1.status(), StatusCode::OK);
+    let body1 = res1.text().unwrap();
+    let bytes1 = extract_bytes_served(&body1);
+    let monitor1_len = body1.as_bytes().len() as u64;
+    // Initial bytes_served may be 0 if first response hasn't been recorded yet when fetched.
+    assert!(
+        bytes1 <= monitor1_len * 2,
+        "unexpectedly large initial bytes_served: {bytes1}"
+    );
+
+    // Download file
+    let res_file = client
+        .get(format!("http://{}/monitor_test.txt", server.addr))
+        .send()
+        .unwrap();
+    assert_eq!(res_file.status(), StatusCode::OK);
+    let file_body = res_file.text().unwrap();
+    let file_len = file_body.as_bytes().len() as u64; // Should be 29
+
+    // Second monitor fetch
+    let res2 = client
+        .get(format!("http://{}/monitor?json=1", server.addr))
+        .send()
+        .unwrap();
+    assert_eq!(res2.status(), StatusCode::OK);
+    let body2 = res2.text().unwrap();
+    let bytes2 = extract_bytes_served(&body2);
+    let monitor2_len = body2.as_bytes().len() as u64;
+
+    // File bytes should appear in delta between monitor fetches minus monitor response body itself.
+    let delta = bytes2.saturating_sub(bytes1);
+    // Allow small variance if headers counted; require at least file_len and not wildly larger.
+    assert!(
+        delta >= file_len,
+        "bytes_served delta {delta} did not include file bytes {file_len}"
+    );
+    assert!(
+        delta < file_len + 4096,
+        "bytes_served delta {delta} unreasonably larger than file {file_len}"
+    );
+
+    // Third monitor fetch to ensure monotonic increase
+    let res3 = client
+        .get(format!("http://{}/monitor?json=1", server.addr))
+        .send()
+        .unwrap();
+    assert_eq!(res3.status(), StatusCode::OK);
+    let body3 = res3.text().unwrap();
+    let bytes3 = extract_bytes_served(&body3);
+    assert!(bytes3 >= bytes2, "bytes_served should be non-decreasing");
+}
+
+#[test]
+fn test_monitor_html_served() {
+    let server = setup_test_server();
+    let client = Client::new();
+
+    let res = client
+        .get(format!("http://{}/monitor", server.addr))
+        .send()
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = res.text().unwrap();
+    assert!(body.contains("<html"));
+    assert!(body.to_lowercase().contains("monitor"));
+}


### PR DESCRIPTION
# PR: Monitoring Dashboard & Accurate Byte Accounting

## Summary
Add unified monitoring via `/monitor` (HTML dashboard + JSON API), correct byte accounting, documentation updates, and tests.

## Changes
- Feature: `/monitor` HTML dashboard (auto-refresh) and `/monitor?json=1` JSON stats
- Metrics: Requests, errors, bytes served (body only), uptime, upload statistics
- Fix: Accurate `bytes_served` tracking in `send_response`
- Tests: `tests/monitor_test.rs` (HTML presence, JSON schema subset, byte growth)
- Docs: Updated `README.md`, `doc/API_REFERENCE.md`, `doc/ARCHITECTURE.md`; added `doc/MONITORING.md`
- Refactor: Removed temporary counting wrapper; centralized stats recording in response path
- Template: Embedded monitor page (no external assets)

## JSON Schema (Excerpt)
```json
{
  "requests": { "total": 0, "successful": 0, "errors": 0, "bytes_served": 0, "uptime_secs": 0 },
  "downloads": { "bytes_served": 0 },
  "uploads": {
    "total_uploads": 0, "successful_uploads": 0, "failed_uploads": 0,
    "files_uploaded": 0, "upload_bytes": 0, "average_upload_size": 0,
    "largest_upload": 0, "concurrent_uploads": 0,
    "average_processing_time": 0.0, "success_rate": 0.0
  }
}
```

## Rationale
Provides built-in observability without external dependencies and fixes previously static download byte counter.

## Verification
- New monitor tests pass
- Manual file download increases `bytes_served`
- Existing endpoints unaffected (backward compatible)

## Follow-Ups (Optional)
- Active connection count
- Per-endpoint metrics
- Prometheus/OpenMetrics exporter
- Rolling rate windows (RPS, throughput)
- Optional auth toggle for `/monitor`

## Checklist
- [x] Feature implemented
- [x] Tests added
- [x] Documentation updated
- [x] Formatting & lint clean
- [x] Backward compatible

---
